### PR TITLE
replacing QgsMessageLog.LEVEL by Qgis.Level

### DIFF
--- a/Visor_UI.py
+++ b/Visor_UI.py
@@ -620,9 +620,9 @@ class Visor(QtWidgets.QDockWidget, FORM_CLASS):
         self.postInformationMessageToUser("Layer '"+image[1]+"' ["+image[2]+"]retrieved")
         layer = image[0]
         if layer and layer.isValid():
-            QgsMapLayerRegistry.instance().addMapLayer(layer)
+            QgsProject.instance().addMapLayer(layer)
             iface.zoomToActiveLayer()
-            iface.legendInterface().refreshLayerSymbology(layer)
+            iface.layerTreeView().refreshLayerSymbology(layer.id())
         else:
             self.postInformationMessageToUser("There was a problem loading the layer.")
 

--- a/libvisor/ThreddsMapperGeneric.py
+++ b/libvisor/ThreddsMapperGeneric.py
@@ -249,7 +249,7 @@ class ThreddsCatalogInfo(QObject):
             page = urllib.request.urlopen(self.threddsMainCatalog+r'/'+self.threddsCatalogFileName,
                                 timeout=self.NetworkRequestTimeout)
         except (HTTPException, URLError, ValueError) as e:
-            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )
+            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", Qgis.Critical )
             raise e
 
         string = page.read()

--- a/libvisor/VisorController.py
+++ b/libvisor/VisorController.py
@@ -93,7 +93,7 @@ class VisorController(QObject):
             self.serverDataService.hide()
         except (HTTPException, URLError, ValueError, timeout):
             self.errorMessage.emit("Error fetching datasets: Server unreachable")
-            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )
+            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", Qgis.Critical )
 
     def asyncQueryDataset(self, depth=0):
         """Will request an asynchronous update of the underlying
@@ -107,14 +107,14 @@ class VisorController(QObject):
             threading.Thread(target = self._fetchDatasetList, args=(depth,)).start()
         except (HTTPException, URLError, ValueError, timeout):
             self.errorMessage.emit("Error fetching datasets: Server unreachable or corrupt data found.")
-            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )
+            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", Qgis.Critical )
 
     def _fetchDatasetList(self, depth):
         try:
             self.InfoService.fetchAvailableDatasets(depth)
         except (HTTPException, URLError, ValueError, timeout) as e:
             self.errorMessage.emit("Error fetching datasets: URL not found")
-            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )
+            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", Qgis.Critical )
 
     @pyqtSlot(list, str)
     def _onNewDataSetListRetrieved(self, dataSetList, serverName):
@@ -157,7 +157,7 @@ class VisorController(QObject):
             self.threddsDataSetUpdated.emit(dataSetObject)
         except (HTTPException, URLError, ValueError, timeout):
             self.errorMessage.emit("Error fetching datasets: Server unreachable")
-            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )
+            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", Qgis.Critical )
 
     def getMapObject(self, mapName, parentSetName, projectDataSet):
         """Will take the requested map name (mapName), the map parent sub set
@@ -212,7 +212,7 @@ class VisorController(QObject):
                 #print("emitting from controller... "+str(mapInfoList.values()[0]))
                 self.mapInfoRetrieved.emit(list(mapInfoList.values())[0])
             except IndexError:
-                QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )
+                QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", Qgis.Critical )
                 return None
 
 
@@ -244,7 +244,7 @@ class VisorController(QObject):
     def notAuthorized(self):
         notAuth = NotAuthorized.NotAuthorized()
         if notAuth.exec_() == QtWidgets.QDialog.Accepted:
-            QgsMessageLog.logMessage(traceback.format_exc(), "Protected dataset, not authorized", QgsMessageLog.CRITICAL )
+            QgsMessageLog.logMessage(traceback.format_exc(), "Protected dataset, not authorized", Qgis.Critical )
             self.standardMessage.emit("Protected dataset, not authorized")
 
                 
@@ -263,8 +263,8 @@ class VisorController(QObject):
             lectorWMS = WMS.WMSparser(threddsMapObject.getWMS())
             lectorWMS.createMapLayer(layerName,styleName,boundingBox, timeRequested)
             resultImage = (lectorWMS.getLastCreatedMapLayer(),layerName,"WMS")
-            QgsMessageLog.logMessage("WMS Layer Name: " + layerName, "THREDDS Explorer", QgsMessageLog.INFO )
-            QgsMessageLog.logMessage("WMS timeRequested: " + timeRequested, "THREDDS Explorer", QgsMessageLog.INFO )
+            QgsMessageLog.logMessage("WMS Layer Name: " + layerName, "THREDDS Explorer", Qgis.Info )
+            QgsMessageLog.logMessage("WMS timeRequested: " + timeRequested, "THREDDS Explorer", Qgis.Info )
             self.mapImageRetrieved.emit(resultImage)
 
     def asyncFetchWMSImageFile(self, threddsMapObject, layerName, styleName, timeRangeRequested, boundingBox):
@@ -365,7 +365,7 @@ class VisorController(QObject):
             msg  = "WCS capabilities URL: {img}\n".format(img=imageurl)
             msg += "WCS timeRequested: {tr}\n".format(tr=timeRequested)
             msg += "WCS coverage: {cn}".format(cn=coverageName)
-            QgsMessageLog.logMessage(msg, "THREDDS Explorer", QgsMessageLog.INFO)
+            QgsMessageLog.logMessage(msg, "THREDDS Explorer", Qgis.Info)
 
             resultImage = (lectorWCS.generateLayer(coverageName, timeRequested, boundingBox=bbox), coverageName, "WCS")
             self.mapImageRetrieved.emit(resultImage)
@@ -401,7 +401,7 @@ class VisorController(QObject):
         try:
             self.batchDownloadFinished.emit(list(layerDictionary.values()), workerObject.getJobName())
         except KeyError:
-            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )
+            QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", Qgis.Critical )
             # Might happen if a thread is cancelled in the last frame download,
             # as it'll already have been queued for removal from the threadsInUse dict
             pass

--- a/libvisor/animation/AnimationController2.py
+++ b/libvisor/animation/AnimationController2.py
@@ -160,7 +160,7 @@ class Controller(QObject):
                     self.pause()
                     self.errorSignal.emit("A layer for this animation was not found.\nWas it removed?"\
                                           " Please, click\nagain on prepare animation to fix this issue.")
-                    QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )
+                    QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", Qgis.Critical )
                 self.framesShown.append(layer)
             except KeyError:
                 #QgsMessageLog.logMessage(traceback.format_exc(), "THREDDS Explorer", QgsMessageLog.CRITICAL )


### PR DESCRIPTION
Just some small changes I had to do so that THREDDSExplorer could load a TDS server in a system with the following configuration (basically QGIS 3.8.3, Linux Mint 19.2, Kernel 4.15.0-66-generic):

![Screenshot_2019-10-23_22-31-25](https://user-images.githubusercontent.com/13545615/67445880-e7187880-f5e4-11e9-8321-17a08da7761e.png)

I only managed to load a THREDDS server running local (localhost) as show bellow, when opening an external TDS (e.g. Unidata, NOAA, Santander Meteo) QGIS crashed hard (`Aborted (core dumped)`). I am still trying to find the cause.

![Screenshot_2019-10-23_22-39-26](https://user-images.githubusercontent.com/13545615/67446154-ff3cc780-f5e5-11e9-8991-ef65b5ed8ce5.png)